### PR TITLE
Add cfn-lint and cfn_nag pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,11 @@ repos:
     hooks:
       - id: cfn-python-lint
         files: templates/.*\.(json|yml|yaml)$
+
+  - repo: local
+    hooks:
+      - id: dockerfile-provides-entrypoint
+        name: cfn_nag
+        language: docker_image
+        entry: stelligent/cfn_nag:latest
+        files: templates/.*\.(json|yml|yaml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,9 @@ repos:
     hooks:
       - id: prettier
         name: Prettier
+
+  - repo: https://github.com/aws-cloudformation/cfn-python-lint
+    rev: v0.28.2
+    hooks:
+      - id: cfn-python-lint
+        files: templates/.*\.(json|yml|yaml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,4 @@ repos:
         language: docker_image
         entry: stelligent/cfn_nag:latest
         files: templates/.*\.(json|yml|yaml)$
+        args: ["--fail-on-warnings"]

--- a/templates/template.yaml
+++ b/templates/template.yaml
@@ -1,0 +1,28 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+
+Resources:
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retail
+    Properties:
+      LoggingConfiguration:
+        DestinationBucketName: s3://log-bucket
+        LogFilePrefix: s3-log-
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+  S3Policy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket:
+        Ref: S3Bucket
+      PolicyDocument:
+        Statement:
+          - Action:
+              - s3:GetObject
+            Effect: Allow
+            Resource: arn:aws:s3:::s3Bucket/*
+            Principal:
+              AWS: arn:aws:iam:1234567890:root


### PR DESCRIPTION
This pull request introduces pre-commit hooks to run the [cfn-lint](https://github.com/aws-cloudformation/cfn-python-lint) and [cfn_nag](https://github.com/stelligent/cfn_nag) tools against AWS CloudFormation templates.

These hooks, in addition to the base hooks introduced in the [git-template](https://github.com/ShahradR/git-template) repository, analyse CloudFormation templates against best practices.

Note that hooks are configured to follow the TaskCat folder structure – in this case, pre-commit is configured to only analyse YAML and JSON files in the `templates` directory.

The expected folder structure is shown below (taken from aws-quickstart/taskcat#25):
```
├── ci
├── scripts
├── submodules
└── templates
```

TaskCat itself is not included as a Git hook, due to its long execution time (it will actually deploy CloudFormation resources in AWS, which can take a bit of time). However, it will be introduced as a CI/CD pipeline step in a future pull request.

# AWS CloudFormation Linter
AWS CloudFormation Linter (`cfn-lint`) validates templates against the CloudFormation specification, and runs some additional checks.

For more details, see the [cfn-python-lint GitHub repository](https://github.com/aws-cloudformation/cfn-python-lint), and this post on the [AWS Management & Governance blog](https://aws.amazon.com/blogs/mt/git-pre-commit-validation-of-aws-cloudformation-templates-with-cfn-lint/)

[![asciicast](https://asciinema.org/a/308273.svg)](https://asciinema.org/a/308273)

# Stelligent cfn_nag
Stelligent `cfn_nag` identifies patterns in CloudFormation templates that may indicate insecure infrastucture. For more details about `cfn_nag`, see the [cfn_nag GitHub repository](https://github.com/stelligent/cfn_nag), and this post on [Stelligent's blog](https://stelligent.com/2016/04/07/finding-security-problems-early-in-the-development-process-of-a-cloudformation-template-with-cfn-nag/).

[![asciicast](https://asciinema.org/a/308270.svg)](https://asciinema.org/a/308270)

Because the repository does not include the `.pre-commit-hooks.yaml` file, we cannot simply reference the repository and have pre-commit generate a hook for us.

However, the team maintaining the project has provided a [container image](https://hub.docker.com/r/stelligent/cfn_nag) on Docker Hub with `cfn_nag` installed. We can configure pre-commit to pull that container image and analyse the files there.

If running on Windows, the best combination to make this hook work is by using WSL2 with the [Docker WSL2 based engine](https://docs.docker.com/docker-for-windows/wsl-tech-preview/), outside of development containers. See #2 for more details.